### PR TITLE
Allow changes to perNote and perUser Spark interpreter settings

### DIFF
--- a/docker/conf/interpreter.json.template
+++ b/docker/conf/interpreter.json.template
@@ -297,8 +297,8 @@
       "option": {
         "remote": true,
         "port": -1,
-        "perNote": "shared",
-        "perUser": "isolated",
+        "perNote": "{{ c.SPARK_INTERPRETER_PER_NOTE | default(value='isolated') }}",
+        "perUser": "{{ c.SPARK_INTERPRETER_PER_USER | default(value='isolated') }}",
         "isExistingProcess": false,
         "setPermission": false,
         "owners": [],


### PR DESCRIPTION
By simply defining the right env var.

Note this does change the default of `perNote` to `isolated`, which makes sense if one is using the dynamic JAR loader.