### PR TITLE
Update JAR loader and add pac4j env domain authorizer

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,16 +20,15 @@ RUN if [ ! -z "${ZEPPELIN_OTHER_INTERPRETERS}" ]; then \
         ./bin/install-interpreter.sh --name "${ZEPPELIN_OTHER_INTERPRETERS}"; \
     fi
 
-RUN set -euo pipefail && \
-    # Install Shiro authorization related JARs
-    wget -P ${ZEPPELIN_HOME}/lib/ http://central.maven.org/maven2/io/buji/buji-pac4j/4.0.0/buji-pac4j-4.0.0.jar; \
-    wget -P ${ZEPPELIN_HOME}/lib/ http://central.maven.org/maven2/org/pac4j/pac4j-core/3.2.0/pac4j-core-3.2.0.jar; \
-    wget -P ${ZEPPELIN_HOME}/lib/ http://central.maven.org/maven2/org/pac4j/pac4j-oauth/3.2.0/pac4j-oauth-3.2.0.jar; \
-    wget -P ${ZEPPELIN_HOME}/lib/ http://central.maven.org/maven2/org/apache/shiro/shiro-web/1.4.0/shiro-web-1.4.0.jar; \
-    wget -P ${ZEPPELIN_HOME}/lib/ http://central.maven.org/maven2/org/apache/shiro/shiro-core/1.4.0/shiro-core-1.4.0.jar; \
-    # Install JAR loader
-    wget -P ${SPARK_HOME}/jars/ https://github.com/datagovsg/zeppelin-jar-loader/releases/download/v0.1.0/zeppelin-jar-loader-v0.1.0.jar; \
-    :
+# Install JAR loader
+ARG ZEPPELIN_JAR_LOADER_VERSION=v0.2.0
+ENV ZEPPELIN_JAR_LOADER_VERSION "${ZEPPELIN_JAR_LOADER_VERSION}"
+RUN wget -P ${SPARK_HOME}/jars/ https://github.com/datagovsg/zeppelin-jar-loader/releases/download/${ZEPPELIN_JAR_LOADER_VERSION}/zeppelin-jar-loader-${ZEPPELIN_JAR_LOADER_VERSION}.jar
+
+# Install env domain authorizer
+ARG PAC4J_AUTHORIZER_VERSION=v0.1.0
+ENV PAC4J_AUTHORIZER_VERSION "${PAC4J_AUTHORIZER_VERSION}"
+RUN wget -P ${ZEPPELIN_HOME}/lib/ https://github.com/datagovsg/pac4j-authorizer/releases/download/${PAC4J_AUTHORIZER_VERSION}/pac4j-authorizer-${PAC4J_AUTHORIZER_VERSION}.jar
 
 RUN set -euo pipefail && \
     # Install gosu for non-root execution

--- a/README.md
+++ b/README.md
@@ -2,7 +2,12 @@
 
 [![Codefresh build status]( https://g.codefresh.io/api/badges/pipeline/dsaid/datagovsg%2Fzeppelin%2Fzeppelin?branch=master&key=eyJhbGciOiJIUzI1NiJ9.NWNhNDBjNDA1MTMxODZjZjdhMTUyYjQx.uEnKk6__Qzfhrurzdo57Oly3AhBgrjFWZZrovG-m-8E&type=cf-1)]( https://g.codefresh.io/pipelines/zeppelin/builds?repoOwner=datagovsg&repoName=zeppelin&serviceName=datagovsg%2Fzeppelin&filter=trigger:build~Build;branch:master;pipeline:5cf86ebd38d1cd3c3a44c178~zeppelin)
 
-Zeppelin Dockerfile set-up with a wrapping dynamic GitHub releases JAR loader.
+Zeppelin Dockerfile set-up with the following enhancements:
+
+- Dynamic GitHub releases JAR loader. See
+  [here](how-to-use-the-dynamic-JAR-loader) for how to use.
+- `pac4j` additional environment variable based email domain authorization.
+  See [here](https://github.com/datagovsg/pac4j-authorizer) for more details.
 
 This set-up is opinionated towards Spark, as such, many of the Spark
 configuration values are set as values that can be interpolated by
@@ -63,12 +68,12 @@ z.reset() /* z is an implicit value of type org.apache.zeppelin.spark.dep.SparkD
 // Saves JAR asset from GitHub release into local filesystem and loads JAR
 zepjarloader.github.Loader.loadJar(
     z,
-    "checkstyle/checkstyle",         /* github_owner/repo_name */
-    "checkstyle-8.21",               /* tag_name */
-    Some("checkstyle-8.21-all.jar"), /* Some(asset_name) if more than one assets, None if there's only one asset */
-    None,                            /* Some(sys.env.get("GITHUB_API_TOKEN").get) if private repo, None if no token needed */
-    "/tmp/checkstyle-8.21-all.jar",  /* local_file_path to save into */
-    true)                            /* Optional param (true), true to read from local_file_path first (cache), false to always fetch from scratch */
+    "checkstyle/checkstyle",    /* github_owner/repo_name */
+    "checkstyle-8.21",          /* tag_name */
+    "checkstyle-8.21-all.jar",  /* asset_name */
+    None,                       /* Some(sys.env.get("GITHUB_API_TOKEN").get) if private repo, None if no token needed */
+    "/tmp/",                    /* local_file_dir_or_path to save into */
+    true)                       /* Optional param (true), true to read from local_file_path first (cache), false to always fetch from scratch */
 ```
 
 Para #2

--- a/codefresh.yml
+++ b/codefresh.yml
@@ -24,6 +24,8 @@ steps:
     - ZEPPELIN_VERSION=0.8.1
     - SPARK_VERSION=2.4.0
     - HADOOP_VERSION=3.1.0
+    - ZEPPELIN_JAR_LOADER_VERSION=v0.2.0
+    - PAC4J_AUTHORIZER_VERSION=v0.1.0
 
   test_zeppelin-0_8_1_spark-2_4_0_hadoop-3_1_0:
     type: composition
@@ -34,7 +36,7 @@ steps:
       version: '2'
       services:
         zeppelin:
-          image: ${{CF_REPO_OWNER}}/${{CF_REPO_NAME}}:0.8.1_spark-2.4.0_hadoop-3.1.0
+          image: ${{build_zeppelin-0_8_1_spark-2_4_0_hadoop-3_1_0}}
           ports:
           - 8080
     composition_candidates:


### PR DESCRIPTION
The Shiro authorization related JARs were removed for the following reasons:
- It simply doesn't work with the default `shiro.ini.template` set-up from official Zeppelin. The config file only seems to work with the Shiro JAR it came with, which is of version `1.3.2` instead of `1.4.0`.
- The additional `pac4j-authorizer` is JAR assembled with the JAR files below, which is good since we need not taint the original Zeppelin set-up with too many peripheral JAR files, and only include in the enhancement JAR files that provide us with the main features.