### PR TITLE
Allows for dual Scala 2.11 and 2.12 builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,18 +15,24 @@ ARG ZEPPELIN_VERSION
 ENV ZEPPELIN_VERSION "${ZEPPELIN_VERSION}"
 
 # Install Zeppelin from pre-built package
-RUN wget -O - https://archive.apache.org/dist/zeppelin/zeppelin-${ZEPPELIN_VERSION}/zeppelin-${ZEPPELIN_VERSION}-bin-netinst.tgz | \
-        tar xz --strip-components=1 -C ${ZEPPELIN_HOME} zeppelin-${ZEPPELIN_VERSION}-bin-netinst
+ARG ZEPPELIN_OTHER_INTERPRETERS
 
-ARG ZEPPELIN_OTHER_INTERPRETERS=
-RUN if [ ! -z "${ZEPPELIN_OTHER_INTERPRETERS}" ]; then \
+RUN set -euo pipefail && \
+    wget -O - https://archive.apache.org/dist/zeppelin/zeppelin-${ZEPPELIN_VERSION}/zeppelin-${ZEPPELIN_VERSION}-bin-netinst.tgz | \
+        tar xz --strip-components=1 -C ${ZEPPELIN_HOME} zeppelin-${ZEPPELIN_VERSION}-bin-netinst; \
+    if [ ! -z "${ZEPPELIN_OTHER_INTERPRETERS}" ]; then \
         ./bin/install-interpreter.sh --name "${ZEPPELIN_OTHER_INTERPRETERS}"; \
-    fi
+    fi; \
+    :
 
 # Install JAR loader
 ARG ZEPPELIN_JAR_LOADER_VERSION=v0.2.1
 ENV ZEPPELIN_JAR_LOADER_VERSION "${ZEPPELIN_JAR_LOADER_VERSION}"
-RUN wget -P ${SPARK_HOME}/jars/ https://github.com/dsaidgovsg/zeppelin-jar-loader/releases/download/${ZEPPELIN_JAR_LOADER_VERSION}/zeppelin-jar-loader_${SCALA_VERSION}-${ZEPPELIN_JAR_LOADER_VERSION}.jar
+ARG SCALA_VERSION
+
+RUN set -euo pipefail && \
+    wget -P ${SPARK_HOME}/jars/ https://github.com/dsaidgovsg/zeppelin-jar-loader/releases/download/${ZEPPELIN_JAR_LOADER_VERSION}/zeppelin-jar-loader_${SCALA_VERSION}-${ZEPPELIN_JAR_LOADER_VERSION}.jar; \
+    :
 
 RUN set -euo pipefail && \
     # Install gosu for non-root execution
@@ -46,4 +52,4 @@ ENV ZEPPELIN_IMPERSONATE_USER zeppelin
 ENV ZEPPELIN_IMPERSONATE_CMD "gosu zeppelin bash -c "
 ENV ZEPPELIN_IMPERSONATE_SPARK_PROXY_USER false
 
-CMD ["sh", "-c", "${ZEPPELIN_HOME}/run-zeppelin.sh"]
+CMD ["${ZEPPELIN_HOME}/run-zeppelin.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,9 @@
-ARG SPARK_VERSION=2.4.0
-ARG HADOOP_VERSION=3.1.0
-FROM guangie88/spark-custom-addons:${SPARK_VERSION}_hadoop-${HADOOP_VERSION}_hive_pyspark_alpine
+ARG SPARK_VERSION=
+ARG SCALA_VERSION=
+ARG HADOOP_VERSION=
+# Python version doesn't matter much for Zeppelin, so we just default to latest
+ARG PYTHON_VERSION=3.7
+FROM guangie88/spark-custom-addons:${SPARK_VERSION}_scala-${SCALA_VERSION}_hadoop-${HADOOP_VERSION}_python-${PYTHON_VERSION}_hive_pyspark_alpine
 
 WORKDIR /zeppelin
 ENV ZEPPELIN_HOME "/zeppelin"
@@ -8,7 +11,7 @@ RUN mkdir -p "${ZEPPELIN_HOME}"
 
 ENV ZEPPELIN_NOTEBOOK "/zeppelin/notebook"
 
-ARG ZEPPELIN_VERSION=0.8.1
+ARG ZEPPELIN_VERSION
 ENV ZEPPELIN_VERSION "${ZEPPELIN_VERSION}"
 
 # Install Zeppelin from pre-built package
@@ -21,21 +24,16 @@ RUN if [ ! -z "${ZEPPELIN_OTHER_INTERPRETERS}" ]; then \
     fi
 
 # Install JAR loader
-ARG ZEPPELIN_JAR_LOADER_VERSION=v0.2.0
+ARG ZEPPELIN_JAR_LOADER_VERSION=v0.2.1
 ENV ZEPPELIN_JAR_LOADER_VERSION "${ZEPPELIN_JAR_LOADER_VERSION}"
-RUN wget -P ${SPARK_HOME}/jars/ https://github.com/datagovsg/zeppelin-jar-loader/releases/download/${ZEPPELIN_JAR_LOADER_VERSION}/zeppelin-jar-loader-${ZEPPELIN_JAR_LOADER_VERSION}.jar
-
-# Install env domain authorizer
-ARG PAC4J_AUTHORIZER_VERSION=v0.1.0
-ENV PAC4J_AUTHORIZER_VERSION "${PAC4J_AUTHORIZER_VERSION}"
-RUN wget -P ${ZEPPELIN_HOME}/lib/ https://github.com/datagovsg/pac4j-authorizer/releases/download/${PAC4J_AUTHORIZER_VERSION}/pac4j-authorizer-${PAC4J_AUTHORIZER_VERSION}.jar
+RUN wget -P ${SPARK_HOME}/jars/ https://github.com/dsaidgovsg/zeppelin-jar-loader/releases/download/${ZEPPELIN_JAR_LOADER_VERSION}/zeppelin-jar-loader_${SCALA_VERSION}-${ZEPPELIN_JAR_LOADER_VERSION}.jar
 
 RUN set -euo pipefail && \
     # Install gosu for non-root execution
     apk add --no-cache su-exec; \
     ln -s /sbin/su-exec /usr/bin/gosu; \
     # Install tera-cli for runtime interpolation
-    wget https://github.com/guangie88/tera-cli/releases/download/v0.1.1/tera_linux_amd64; \
+    wget https://github.com/guangie88/tera-cli/releases/download/v0.2.1/tera_linux_amd64; \
     chmod +x tera_linux_amd64; \
     mv tera_linux_amd64 /usr/local/bin/tera; \
     :

--- a/Dockerfile
+++ b/Dockerfile
@@ -52,4 +52,5 @@ ENV ZEPPELIN_IMPERSONATE_USER zeppelin
 ENV ZEPPELIN_IMPERSONATE_CMD "gosu zeppelin bash -c "
 ENV ZEPPELIN_IMPERSONATE_SPARK_PROXY_USER false
 
-CMD ["${ZEPPELIN_HOME}/run-zeppelin.sh"]
+# Env var not expanded without Dockerfile, so need to go through sh
+CMD ["sh", "-c", "${ZEPPELIN_HOME}/run-zeppelin.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,8 @@
-ARG SPARK_VERSION=
-ARG SCALA_VERSION=
-ARG HADOOP_VERSION=
+ARG SPARK_VERSION
+ARG SCALA_VERSION
+ARG HADOOP_VERSION
 # Python version doesn't matter much for Zeppelin, so we just default to latest
-ARG PYTHON_VERSION=3.7
+ARG PYTHON_VERSION="3.7"
 FROM guangie88/spark-custom-addons:${SPARK_VERSION}_scala-${SCALA_VERSION}_hadoop-${HADOOP_VERSION}_python-${PYTHON_VERSION}_hive_pyspark_alpine
 
 WORKDIR /zeppelin
@@ -15,7 +15,7 @@ ARG ZEPPELIN_VERSION
 ENV ZEPPELIN_VERSION "${ZEPPELIN_VERSION}"
 
 # Install Zeppelin from pre-built package
-ARG ZEPPELIN_OTHER_INTERPRETERS
+ARG ZEPPELIN_OTHER_INTERPRETERS=""
 
 RUN set -euo pipefail && \
     wget -O - https://archive.apache.org/dist/zeppelin/zeppelin-${ZEPPELIN_VERSION}/zeppelin-${ZEPPELIN_VERSION}-bin-netinst.tgz | \
@@ -26,7 +26,7 @@ RUN set -euo pipefail && \
     :
 
 # Install JAR loader
-ARG ZEPPELIN_JAR_LOADER_VERSION=v0.2.1
+ARG ZEPPELIN_JAR_LOADER_VERSION="v0.2.1"
 ENV ZEPPELIN_JAR_LOADER_VERSION "${ZEPPELIN_JAR_LOADER_VERSION}"
 ARG SCALA_VERSION
 

--- a/README.md
+++ b/README.md
@@ -1,13 +1,13 @@
 # Zeppelin
 
-[![Codefresh build status]( https://g.codefresh.io/api/badges/pipeline/dsaid/datagovsg%2Fzeppelin%2Fzeppelin?branch=master&key=eyJhbGciOiJIUzI1NiJ9.NWNhNDBjNDA1MTMxODZjZjdhMTUyYjQx.uEnKk6__Qzfhrurzdo57Oly3AhBgrjFWZZrovG-m-8E&type=cf-1)]( https://g.codefresh.io/pipelines/zeppelin/builds?repoOwner=datagovsg&repoName=zeppelin&serviceName=datagovsg%2Fzeppelin&filter=trigger:build~Build;branch:master;pipeline:5cf86ebd38d1cd3c3a44c178~zeppelin)
+| Scala 2.11 | Scala 2.12 |
+|:-:|:-:|
+| [![Codefresh build status]( https://g.codefresh.io/api/badges/pipeline/dsaid/dsaidgovsg%2Fzeppelin%2Fscala-2.11?branch=master&key=eyJhbGciOiJIUzI1NiJ9.NWNhNDBjNDA1MTMxODZjZjdhMTUyYjQx.uEnKk6__Qzfhrurzdo57Oly3AhBgrjFWZZrovG-m-8E&type=cf-1)]( https://g.codefresh.io/pipelines/scala-2.11/builds?repoOwner=dsaidgovsg&repoName=zeppelin&serviceName=dsaidgovsg%2Fzeppelin&filter=trigger:build~Build;branch:master;pipeline:5d5e4cd6e32ac26b357d3034~scala-2.11) | [![Codefresh build status]( https://g.codefresh.io/api/badges/pipeline/dsaid/dsaidgovsg%2Fzeppelin%2Fscala-2.12?branch=master&key=eyJhbGciOiJIUzI1NiJ9.NWNhNDBjNDA1MTMxODZjZjdhMTUyYjQx.uEnKk6__Qzfhrurzdo57Oly3AhBgrjFWZZrovG-m-8E&type=cf-1)]( https://g.codefresh.io/pipelines/scala-2.12/builds?repoOwner=dsaidgovsg&repoName=zeppelin&serviceName=dsaidgovsg%2Fzeppelin&filter=trigger:build~Build;branch:master;pipeline:5d773c683794ab51f4cbd16d~scala-2.12) |
 
 Zeppelin Dockerfile set-up with the following enhancements:
 
 - Dynamic GitHub releases JAR loader. See
   [here](#how-to-use-the-dynamic-JAR-loader) for how to use.
-- `pac4j` additional environment variable based email domain authorization.
-  See [here](https://github.com/datagovsg/pac4j-authorizer) for more details.
 
 This set-up is opinionated towards Spark, as such, many of the Spark
 configuration values are set as values that can be interpolated by

--- a/codefresh.yml
+++ b/codefresh.yml
@@ -22,12 +22,12 @@ steps:
     stage: build
     title: Build image zeppelin
     image_name: ${{CF_REPO_OWNER}}/${{CF_REPO_NAME}}
-    tag: test_${ZEPPELIN_VERSION}_spark-${SPARK_VERSION}_scala-${SCALA_VERSION}_hadoop-${HADOOP_VERSION}
+    tag: test_${{ZEPPELIN_VERSION}}_spark-${{SPARK_VERSION}}_scala-${{SCALA_VERSION}}_hadoop-${{HADOOP_VERSION}}
     build_arguments:
-    - ZEPPELIN_VERSION=${ZEPPELIN_VERSION}
-    - SPARK_VERSION=${SPARK_VERSION}
-    - SCALA_VERSION=${SCALA_VERSION}
-    - HADOOP_VERSION=${HADOOP_VERSION}
+    - ZEPPELIN_VERSION=${{ZEPPELIN_VERSION}}
+    - SPARK_VERSION=${{SPARK_VERSION}}
+    - SCALA_VERSION=${{SCALA_VERSION}}
+    - HADOOP_VERSION=${{HADOOP_VERSION}}
 
   test_zeppelin:
     type: composition
@@ -51,7 +51,7 @@ steps:
     stage: push
     title: Push image zeppelin
     candidate: ${{build_zeppelin}}
-    tag: ${ZEPPELIN_VERSION}_spark-${SPARK_VERSION}_scala-${SCALA_VERSION}_hadoop-${HADOOP_VERSION}
+    tag: ${{ZEPPELIN_VERSION}}_spark-${{SPARK_VERSION}}_scala-${{SCALA_VERSION}}_hadoop-${{HADOOP_VERSION}}
     registry: cfcr
     when:
       branch:

--- a/codefresh.yml
+++ b/codefresh.yml
@@ -5,6 +5,7 @@ stages:
 - test
 - push
 
+# Requires SCALA_VERSION (just x.y) to be specified
 steps:
   main_clone:
     title: Clone main repository
@@ -16,29 +17,28 @@ steps:
 
   # Step cannot contain period for now
   # DO NOT push to the actual tag first, only push after PR is merged
-  build_zeppelin-0_8_1_spark-2_4_0_hadoop-3_1_0:
+  build_zeppelin:
     type: build
     stage: build
-    title: Build image zeppelin-0.8.1_spark-2.4.0_hadoop-3.1.0
+    title: Build image zeppelin
     image_name: ${{CF_REPO_OWNER}}/${{CF_REPO_NAME}}
-    tag: test_0.8.1_spark-2.4.0_hadoop-3.1.0
+    tag: test_${ZEPPELIN_VERSION}_spark-${SPARK_VERSION}_scala-${SCALA_VERSION}_hadoop-${HADOOP_VERSION}
     build_arguments:
-    - ZEPPELIN_VERSION=0.8.1
-    - SPARK_VERSION=2.4.0
-    - HADOOP_VERSION=3.1.0
-    - ZEPPELIN_JAR_LOADER_VERSION=v0.2.0
-    - PAC4J_AUTHORIZER_VERSION=v0.1.0
+    - ZEPPELIN_VERSION=${ZEPPELIN_VERSION}
+    - SPARK_VERSION=${SPARK_VERSION}
+    - SCALA_VERSION=${SCALA_VERSION}
+    - HADOOP_VERSION=${HADOOP_VERSION}
 
-  test_zeppelin-0_8_1_spark-2_4_0_hadoop-3_1_0:
+  test_zeppelin:
     type: composition
     stage: test
-    title: Test image zeppelin-0.8.1_spark-2.4.0_hadoop-3.1.0
+    title: Test image zeppelin
     image_name: ${{CF_REPO_OWNER}}/${{CF_REPO_NAME}}
     composition:
       version: '2'
       services:
         zeppelin:
-          image: ${{build_zeppelin-0_8_1_spark-2_4_0_hadoop-3_1_0}}
+          image: ${{build_zeppelin}}
           ports:
           - 8080
     composition_candidates:
@@ -46,12 +46,12 @@ steps:
         image: gempesaw/curl-jq:latest
         command: sh -c 'sleep 25 && [ "`curl -s http://zeppelin:8080/api/version | jq -r .status`" = "OK" ]'
 
-  push_zeppelin-0_8_1_spark-2_4_0_hadoop-3_1_0:
+  push_zeppelin:
     type: push
     stage: push
-    title: Push image zeppelin-0.8.1_spark-2.4.0_hadoop-3.1.0
-    candidate: ${{build_zeppelin-0_8_1_spark-2_4_0_hadoop-3_1_0}}
-    tag: 0.8.1_spark-2.4.0_hadoop-3.1.0
+    title: Push image zeppelin
+    candidate: ${{build_zeppelin}}
+    tag: ${ZEPPELIN_VERSION}_spark-${SPARK_VERSION}_scala-${SCALA_VERSION}_hadoop-${HADOOP_VERSION}
     registry: cfcr
     when:
       branch:

--- a/docker/conf/interpreter.json.template
+++ b/docker/conf/interpreter.json.template
@@ -103,136 +103,136 @@
       "properties": {
         "master": {
           "name": "master",
-          "value": "{{ c.SPARK_MASTER | default(value='local[*]') }}",
+          "value": "{{ SPARK_MASTER | default(value='local[*]') }}",
           "type": "string"
         },
         "spark.jars": {
           "name": "spark.jars",
-          "value": "{{ c.SPARK_JARS | default(value='') }}"
+          "value": "{{ SPARK_JARS | default(value='') }}"
         },
         "spark.submit.deployMode": {
           "name": "spark.submit.deployMode",
-          "value": "{{ c.SPARK_SUBMIT_DEPLOYMODE | default(value='client') }}",
+          "value": "{{ SPARK_SUBMIT_DEPLOYMODE | default(value='client') }}",
           "type": "string"
         },
         "spark.app.name": {
           "name": "spark.app.name",
-          "value": "{{ c.SPARK_APP_NAME | default(value='Zeppelin') }}",
+          "value": "{{ SPARK_APP_NAME | default(value='Zeppelin') }}",
           "type": "string"
         },
         "args": {
           "name": "args",
-          "value": "{{ c.SPARK_ARGS | default(value='') }}",
+          "value": "{{ SPARK_ARGS | default(value='') }}",
           "type": "textarea"
         },
         "spark.executor.memory": {
           "name": "spark.executor.memory",
-          "value": "{{ c.SPARK_EXECUTOR_MEMORY | default(value='4G') }}",
+          "value": "{{ SPARK_EXECUTOR_MEMORY | default(value='4G') }}",
           "type": "string"
         },
         "spark.eventLog.enabled": {
           "name": "spark.eventLog.enabled",
-          "value": "{{ c.SPARK_EVENTLOG_ENABLED | default(value='false') }}",
+          "value": "{{ SPARK_EVENTLOG_ENABLED | default(value='false') }}",
           "type": "string"
         },
         "spark.eventLog.dir": {
           "name": "spark.eventLog.dir",
-          "value": "{{ c.SPARK_EVENTLOG_DIR | default(value='') }}",
+          "value": "{{ SPARK_EVENTLOG_DIR | default(value='') }}",
           "type": "string"
         },
         "spark.cores.max": {
           "name": "spark.cores.max",
-          "value": "{{ c.SPARK_CORES_MAX | default(value='') }}",
+          "value": "{{ SPARK_CORES_MAX | default(value='') }}",
           "type": "number"
         },
         "spark.shuffle.service.enabled": {
           "name": "spark.shuffle.service.enabled",
-          "value": "{{ c.SPARK_SHUFFLE_SERVICE_ENABLED | default(value='true') }}",
+          "value": "{{ SPARK_SHUFFLE_SERVICE_ENABLED | default(value='true') }}",
           "type": "string"
         },
         "spark.dynamicAllocation.enabled": {
           "name": "spark.dynamicAllocation.enabled",
-          "value": "{{ c.SPARK_DYNAMICALLOCATION_ENABLED | default(value='true') }}",
+          "value": "{{ SPARK_DYNAMICALLOCATION_ENABLED | default(value='true') }}",
           "type": "string"
         },
         "spark.dynamicAllocation.maxExecutors": {
           "name": "spark.dynamicAllocation.maxExecutors",
-          "value": "{{ c.SPARK_DYNAMICALLOCATION_MAXEXECUTORS | default(value='25') }}",
+          "value": "{{ SPARK_DYNAMICALLOCATION_MAXEXECUTORS | default(value='25') }}",
           "type": "string"
         },
         "spark.dynamicAllocation.cachedExecutorIdleTimeout": {
           "name": "spark.dynamicAllocation.cachedExecutorIdleTimeout",
-          "value": "{{ c.SPARK_DYNAMICALLOCATION_CACHEDEXECUTORIDLETIMEOUT | default(value='60s') }}",
+          "value": "{{ SPARK_DYNAMICALLOCATION_CACHEDEXECUTORIDLETIMEOUT | default(value='60s') }}",
           "type": "string"
         },
         "zeppelin.spark.sql.interpolation": {
           "name": "zeppelin.spark.sql.interpolation",
-          "value": {{ c.ZEPPELIN_SPARK_SQL_INTERPOLATION | default(value='false') }},
+          "value": {{ ZEPPELIN_SPARK_SQL_INTERPOLATION | default(value='false') }},
           "type": "checkbox"
         },
         "zeppelin.spark.concurrentSQL": {
           "name": "zeppelin.spark.concurrentSQL",
-          "value": {{ c.ZEPPELIN_SPARK_CONCURRENTSQL | default(value='false') }},
+          "value": {{ ZEPPELIN_SPARK_CONCURRENTSQL | default(value='false') }},
           "type": "checkbox"
         },
         "zeppelin.spark.importImplicit": {
           "name": "zeppelin.spark.importImplicit",
-          "value": {{ c.ZEPPELIN_SPARK_IMPORTIMPLICIT | default(value='true') }},
+          "value": {{ ZEPPELIN_SPARK_IMPORTIMPLICIT | default(value='true') }},
           "type": "checkbox"
         },
         "zeppelin.dep.additionalRemoteRepository": {
           "name": "zeppelin.dep.additionalRemoteRepository",
-          "value": "{{ c.ZEPPELIN_DEP_ADDITIONALREMOTEREPOSITORY | default(value='spark-packages,http://dl.bintray.com/spark-packages/maven,false;') }}",
+          "value": "{{ ZEPPELIN_DEP_ADDITIONALREMOTEREPOSITORY | default(value='spark-packages,http://dl.bintray.com/spark-packages/maven,false;') }}",
           "type": "textarea"
         },
         "zeppelin.spark.maxResult": {
           "name": "zeppelin.spark.maxResult",
-          "value": "{{ c.ZEPPELIN_SPARK_MAXRESULT | default(value='1000') }}",
+          "value": "{{ ZEPPELIN_SPARK_MAXRESULT | default(value='1000') }}",
           "type": "number"
         },
         "zeppelin.pyspark.python": {
           "name": "zeppelin.pyspark.python",
-          "value": "{{ c.ZEPPELIN_PYSPARK_PYTHON | default(value='python') }}",
+          "value": "{{ ZEPPELIN_PYSPARK_PYTHON | default(value='python') }}",
           "type": "string"
         },
         "zeppelin.spark.enableSupportedVersionCheck": {
           "name": "zeppelin.spark.enableSupportedVersionCheck",
-          "value": {{ c.ZEPPELIN_SPARK_ENABLESUPPORTEDVERSIONCHECK | default(value='true') }},
+          "value": {{ ZEPPELIN_SPARK_ENABLESUPPORTEDVERSIONCHECK | default(value='true') }},
           "type": "checkbox"
         },
         "zeppelin.spark.useNew": {
           "name": "zeppelin.spark.useNew",
-          "value": {{ c.ZEPPELIN_SPARK_USENEW | default(value='true') }},
+          "value": {{ ZEPPELIN_SPARK_USENEW | default(value='true') }},
           "type": "checkbox"
         },
         "zeppelin.dep.localrepo": {
           "name": "zeppelin.dep.localrepo",
-          "value": "{{ c.ZEPPELIN_DEP_LOCALREPO | default(value='local-repo') }}",
+          "value": "{{ ZEPPELIN_DEP_LOCALREPO | default(value='local-repo') }}",
           "type": "string"
         },
         "zeppelin.pyspark.useIPython": {
           "name": "zeppelin.pyspark.useIPython",
-          "value": {{ c.ZEPPELIN_PYSPARK_USEIPYTHON | default(value='true') }},
+          "value": {{ ZEPPELIN_PYSPARK_USEIPYTHON | default(value='true') }},
           "type": "checkbox"
         },
         "zeppelin.spark.sql.stacktrace": {
           "name": "zeppelin.spark.sql.stacktrace",
-          "value": {{ c.ZEPPELIN_SPARK_SQL_STACKTRACE | default(value='false') }},
+          "value": {{ ZEPPELIN_SPARK_SQL_STACKTRACE | default(value='false') }},
           "type": "checkbox"
         },
         "zeppelin.spark.useHiveContext": {
           "name": "zeppelin.spark.useHiveContext",
-          "value": {{ c.ZEPPELIN_SPARK_USEHIVECONTEXT | default(value='true') }},
+          "value": {{ ZEPPELIN_SPARK_USEHIVECONTEXT | default(value='true') }},
           "type": "checkbox"
         },
         "zeppelin.spark.uiWebUrl": {
           "name": "zeppelin.spark.uiWebUrl",
-          "value": "{{ c.ZEPPELIN_SPARK_UIWEBURL | default(value='') }}",
+          "value": "{{ ZEPPELIN_SPARK_UIWEBURL | default(value='') }}",
           "type": "string"
         },
         "zeppelin.spark.printREPLOutput": {
           "name": "zeppelin.spark.printREPLOutput",
-          "value": {{ c.ZEPPELIN_SPARK_PRINTREPLOUTPUT | default(value='true') }},
+          "value": {{ ZEPPELIN_SPARK_PRINTREPLOUTPUT | default(value='true') }},
           "type": "checkbox"
         }
       },
@@ -246,7 +246,7 @@
             "language": "scala",
             "editOnDblClick": false,
             "completionKey": "TAB",
-            "completionSupport": {{ c.ZEPPELIN_SPARKINTERPRETER_COMPLETION_SUPPORT | default(value='false') }}
+            "completionSupport": {{ ZEPPELIN_SPARKINTERPRETER_COMPLETION_SUPPORT | default(value='false') }}
           }
         },
         {
@@ -257,7 +257,7 @@
             "language": "sql",
             "editOnDblClick": false,
             "completionKey": "TAB",
-            "completionSupport": {{ c.ZEPPELIN_SPARKSQLINTERPRETER_COMPLETION_SUPPORT | default(value='false') }}
+            "completionSupport": {{ ZEPPELIN_SPARKSQLINTERPRETER_COMPLETION_SUPPORT | default(value='false') }}
           }
         },
         {
@@ -268,7 +268,7 @@
             "language": "scala",
             "editOnDblClick": false,
             "completionKey": "TAB",
-            "completionSupport": {{ c.ZEPPELIN_SPARKDEPINTERPRETER_COMPLETION_SUPPORT | default(value='false') }}
+            "completionSupport": {{ ZEPPELIN_SPARKDEPINTERPRETER_COMPLETION_SUPPORT | default(value='false') }}
           }
         },
         {
@@ -279,7 +279,7 @@
             "language": "python",
             "editOnDblClick": false,
             "completionKey": "TAB",
-            "completionSupport": {{ c.ZEPPELIN_PYSPARKINTERPRETER_COMPLETION_SUPPORT | default(value='false') }}
+            "completionSupport": {{ ZEPPELIN_PYSPARKINTERPRETER_COMPLETION_SUPPORT | default(value='false') }}
           }
         },
         {
@@ -289,7 +289,7 @@
           "editor": {
             "language": "python",
             "editOnDblClick": false,
-            "completionSupport": {{ c.ZEPPELIN_IPYSPARKINTERPRETER_COMPLETION_SUPPORT | default(value='false') }}
+            "completionSupport": {{ ZEPPELIN_IPYSPARKINTERPRETER_COMPLETION_SUPPORT | default(value='false') }}
           }
         },
         {
@@ -299,7 +299,7 @@
           "editor": {
             "language": "r",
             "editOnDblClick": false,
-            "completionSupport": {{ c.ZEPPELIN_SPARKRINTERPRETER_COMPLETION_SUPPORT | default(value='false') }}
+            "completionSupport": {{ ZEPPELIN_SPARKRINTERPRETER_COMPLETION_SUPPORT | default(value='false') }}
           }
         }
       ],
@@ -307,8 +307,8 @@
       "option": {
         "remote": true,
         "port": -1,
-        "perNote": "{{ c.SPARK_INTERPRETER_PER_NOTE | default(value='isolated') }}",
-        "perUser": "{{ c.SPARK_INTERPRETER_PER_USER | default(value='isolated') }}",
+        "perNote": "{{ SPARK_INTERPRETER_PER_NOTE | default(value='isolated') }}",
+        "perUser": "{{ SPARK_INTERPRETER_PER_USER | default(value='isolated') }}",
         "isExistingProcess": false,
         "setPermission": false,
         "owners": [],

--- a/docker/conf/zeppelin-site.xml.template
+++ b/docker/conf/zeppelin-site.xml.template
@@ -21,19 +21,19 @@
 
 <property>
   <name>zeppelin.server.addr</name>
-  <value>{{ c.SERVER_ADDR | default(value="0.0.0.0") }}</value>
+  <value>{{ SERVER_ADDR | default(value="0.0.0.0") }}</value>
   <description>Server address</description>
 </property>
 
 <property>
   <name>zeppelin.server.port</name>
-  <value>{{ c.ZEPPELIN_PORT | default(value=8080) }}</value>
+  <value>{{ ZEPPELIN_PORT | default(value=8080) }}</value>
   <description>Server port.</description>
 </property>
 
 <property>
   <name>zeppelin.server.ssl.port</name>
-  <value>{{ c.ZEPPELIN_SSL_PORT | default(value=8443) }}</value>
+  <value>{{ ZEPPELIN_SSL_PORT | default(value=8443) }}</value>
   <description>Server ssl port. (used when ssl property is set to true)</description>
 </property>
 
@@ -51,7 +51,7 @@
 
 <property>
   <name>zeppelin.notebook.dir</name>
-  <value>{{ c.ZEPPELIN_NOTEBOOK }}</value>
+  <value>{{ ZEPPELIN_NOTEBOOK }}</value>
   <description>path or URI for notebook persist</description>
 </property>
 
@@ -342,13 +342,13 @@
 
 <property>
   <name>zeppelin.ssl</name>
-  <value>{{ c.ZEPPELIN_SSL | default(value='false') }}</value>
+  <value>{{ ZEPPELIN_SSL | default(value='false') }}</value>
   <description>Should SSL be used by the servers?</description>
 </property>
 
 <property>
   <name>zeppelin.ssl.client.auth</name>
-  <value>{{ c.ZEPPELIN_SSL_CLIENT_AUTH | default(value='false') }}</value>
+  <value>{{ ZEPPELIN_SSL_CLIENT_AUTH | default(value='false') }}</value>
   <description>Should client authentication be used for SSL connections?</description>
 </property>
 
@@ -443,7 +443,7 @@
 {%- if c.USE_INTERPRETER_LIFECYCLEMANAGER and c.USE_INTERPRETER_LIFECYCLEMANAGER == 'true' %}
 
 <property>
-  <name>{{ c.INTERPRETER_LIFECYCLEMANAGER_CLASS | default(value='zeppelin.interpreter.lifecyclemanager.class') }}</name>
+  <name>{{ INTERPRETER_LIFECYCLEMANAGER_CLASS | default(value='zeppelin.interpreter.lifecyclemanager.class') }}</name>
   <value>org.apache.zeppelin.interpreter.lifecycle.TimeoutLifecycleManager</value>
   <description>LifecycleManager class for managing the lifecycle of interpreters, by default interpreter will
   be closed after timeout</description>
@@ -451,13 +451,13 @@
 
 <property>
   <name>zeppelin.interpreter.lifecyclemanager.timeout.checkinterval</name>
-  <value>{{ c.INTERPRETER_LIFECYCLEMANAGER_TIMEOUT_CHECKINTERVAL | default(value=60000) }}</value>
+  <value>{{ INTERPRETER_LIFECYCLEMANAGER_TIMEOUT_CHECKINTERVAL | default(value=60000) }}</value>
   <description>Milliseconds of the interval to checking whether interpreter is time out</description>
 </property>
 
 <property>
   <name>zeppelin.interpreter.lifecyclemanager.timeout.threshold</name>
-  <value>{{ c.INTERPRETER_LIFECYCLEMANAGER_TIMEOUT_THRESHOLD | default(value=3600000) }}</value>
+  <value>{{ INTERPRETER_LIFECYCLEMANAGER_TIMEOUT_THRESHOLD | default(value=3600000) }}</value>
   <description>Milliseconds of the interpreter timeout threshold, by default it is 1 hour</description>
 </property>
 {%- endif %}

--- a/docker/run-zeppelin.sh
+++ b/docker/run-zeppelin.sh
@@ -2,7 +2,8 @@
 set -euo pipefail
 
 # Find all .jar files and comma delimit into a string
-export SPARK_JARS=$(find "${SPARK_HOME}/jars/" -type f -name '*.jar' | paste -sd,)
+SPARK_JARS="$(find "${SPARK_HOME}/jars/" -type f -name '*.jar' | paste -sd,)"
+export SPARK_JARS
 
 # Create interpreter.json
 tera -f ./conf/interpreter.json.template --env > ./conf/interpreter.json
@@ -17,7 +18,7 @@ tera -f ./conf/shiro.ini.template --env > ./conf/shiro.ini
 chmod 600 ./conf/shiro.ini
 
 # Permit notebook directory to be written to
-chown -R zeppelin ${ZEPPELIN_NOTEBOOK}
+chown -R zeppelin "${ZEPPELIN_NOTEBOOK}"
 
 # Start zeppelin
 exec ./bin/zeppelin.sh


### PR DESCRIPTION
Also clean up Tera template files by using updated `tera-cli`, which doesn't require root key `c` to be used anymore.