### PR TITLE
Fix zeppelin vers

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,11 @@
 Zeppelin Dockerfile set-up with the following enhancements:
 
 - Dynamic GitHub releases JAR loader. See
-  [here](#how-to-use-the-dynamic-JAR-loader) for how to use.
+  [here](#how-to-use-the-dynamic-JAR-loader) for how to use. Original repo is in
+  [here](https://github.com/dsaidgovsg/zeppelin-jar-loader).
+- `pac4j` additional environment variable based email domain authorization.
+  See original repo [here](https://github.com/dsaidgovsg/pac4j-authorizer) for
+  more details.
 
 This set-up is opinionated towards Spark, as such, many of the Spark
 configuration values are set as values that can be interpolated by
@@ -24,10 +28,23 @@ Check:
 to get a better feel for the above explanation. Search for `{{` to quickly get
 all the values that can be interpolated by environment variables.
 
+This repo tries its best to never change the environment variables once they are
+part of the above template files, but note that this is a best effort attempt
+and there is indeed a change of naming (or removal), this would not be reflected
+in the Docker image tags.
+
 ## How to have a quick local deployment demo
 
 ```bash
-docker build . -t zeppelin
+SPARK_VERSION="2.4.4"
+SCALA_VERSION="2.12"
+HADOOP_VERSION="3.1.0"
+
+docker build . -t zeppelin \
+    --build-arg SPARK_VERSION="${SPARK_VERSION}" \
+    --build-arg SCALA_VERSION="${SCALA_VERSION}" \
+    --build-arg HADOOP_VERSION="${HADOOP_VERSION}"
+
 docker run --rm -it --name zeppelin -p 8080:8080 zeppelin
 ```
 
@@ -54,8 +71,8 @@ repository or local filesystem. See
 [this](https://zeppelin.apache.org/docs/latest/interpreter/spark.html#3-dynamic-dependency-loading-via-sparkdep-interpreter)
 for more details.
 
-This set-up enhances this capability by
-installing a special JAR to do loading from GitHub release JAR assets.
+This set-up enhances this capability by installing a special JAR to do loading
+from GitHub release JAR assets.
 
 ### Example
 

--- a/codefresh.yml
+++ b/codefresh.yml
@@ -1,6 +1,7 @@
 version: '1.0'
 stages:
 - clone
+- misc
 - build
 - test
 - push
@@ -15,6 +16,14 @@ steps:
     repo: ${{CF_REPO_OWNER}}/${{CF_REPO_NAME}}
     revision: ${{CF_REVISION}}
 
+  extract_zeppelin_version:
+    title: Extract Zeppelin x.y.z version
+    stage: misc
+    image: alpine:3.10
+    commands:
+    - apk add --no-cache curl
+    - cf_export ZEPPELIN_VERSION="$(curl -sL "https://github.com/apache/zeppelin/raw/${ZEPPELIN_REV}/pom.xml" | grep "<name>Zeppelin</name>" -B1 | grep "<version>" | grep -oE "[[:digit:]]+\.[[:digit:]]+\.[[:digit:]]+(-SNAPSHOT)?")"
+
   # Step cannot contain period for now
   # DO NOT push to the actual tag first, only push after PR is merged
   build_zeppelin:
@@ -24,7 +33,7 @@ steps:
     image_name: ${{CF_REPO_OWNER}}/${{CF_REPO_NAME}}
     tag: test_${{ZEPPELIN_VERSION}}_spark-${{SPARK_VERSION}}_scala-${{SCALA_VERSION}}_hadoop-${{HADOOP_VERSION}}
     build_arguments:
-    - ZEPPELIN_VERSION=${{ZEPPELIN_VERSION}}
+    - ZEPPELIN_REV=${{ZEPPELIN_REV}}
     - SPARK_VERSION=${{SPARK_VERSION}}
     - SCALA_VERSION=${{SCALA_VERSION}}
     - HADOOP_VERSION=${{HADOOP_VERSION}}


### PR DESCRIPTION
Fix issue where `ZEPPELIN_VERSION` is not in use, but useful for naming. Codefresh step to extract the version value is added.

Also clean up the README content how what this contains and how to build.