### PR TITLE
V0.8.2 cleanup

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -65,13 +65,6 @@ ENV ZEPPELIN_NOTEBOOK "/zeppelin/notebook"
 # Install JAR loader
 ARG SCALA_VERSION
 
-ARG ZEPPELIN_JAR_LOADER_VERSION="v0.2.1"
-ENV ZEPPELIN_JAR_LOADER_VERSION "${ZEPPELIN_JAR_LOADER_VERSION}"
-
-RUN set -euo pipefail && \
-    wget -P ${SPARK_HOME}/jars/ https://github.com/dsaidgovsg/zeppelin-jar-loader/releases/download/${ZEPPELIN_JAR_LOADER_VERSION}/zeppelin-jar-loader_${SCALA_VERSION}-${ZEPPELIN_JAR_LOADER_VERSION}.jar; \
-    :
-
 # Install custom OAuth authorizer with env domain checker
 # This is required even for general pac4j.oauth
 ARG PAC4J_AUTHORIZER_VERSION="v0.1.1"

--- a/Dockerfile
+++ b/Dockerfile
@@ -44,7 +44,7 @@ RUN set -euo pipefail && \
     # See: https://issues.apache.org/jira/browse/ZEPPELIN-3552 and https://issues.apache.org/jira/browse/ZEPPELIN-3552
     # Ignore -Pscala-${SCALA_VERSION} which is now no longer a valid flag
     # Ignore interpreters based on the official Travis configuration
-    INTERPRETERS="$(cat .travis.yml | grep INTERPRETERS= | grep -oE "'.+'")"; \
+    INTERPRETERS="$(cat .travis.yml | grep INTERPRETERS= | sed -E "s/- INTERPRETERS='(.+)'/\1/" | tr -d " ")"; \
     FLAGS="-DskipTests -Pbuild-distr"; \
     MODULES="-pl ${INTERPRETERS}"; \
     PROFILES="-Pspark-${SPARK_XY_VERSION} -Pspark-scala-${SCALA_VERSION} -Phadoop2"; \

--- a/Dockerfile
+++ b/Dockerfile
@@ -37,17 +37,27 @@ RUN set -euo pipefail && \
     cd -; \
     cd /tmp/zeppelin; \
     SPARK_XY_VERSION="$(echo "${SPARK_VERSION}" | cut -d '.' -f1,2 | tr -d '\n')"; \
+    # The name of zeppelin directory might not be the same as the ZEPPELIN_REV, especially when building "master" where the directory might be "zeppelin-0.9.0-SNAPSHOT"
+    # Below can get the actual Zeppelin version, but can only be done within Docker RUN commands
+    ZEPPELIN_VERSION="$(cat pom.xml | grep "<name>Zeppelin</name>" -B1 | grep "<version>" | grep -oE "[[:digit:]]+\.[[:digit:]]+\.[[:digit:]]+(-SNAPSHOT)?")"; \
+    ZEPPELIN_X_VERSION="$(echo "${ZEPPELIN_VERSION}" | cut -d '.' -f1)"; \
+    ZEPPELIN_Y_VERSION="$(echo "${ZEPPELIN_VERSION}"  | cut -d '.' -f2)"; \
     # Cannot use Hadoop 3 due to some nested dependency version mismatch issue
     # HADOOP_X_VERSION="$(echo "${HADOOP_VERSION}" | cut -d '.' -f1 | tr -d '\n')"; \
     # change_scala_version.sh seems deprecated, doesn't even support 2.12 as a param
     # ./dev/change_scala_version.sh "${SCALA_VERSION}"; \
     # See: https://issues.apache.org/jira/browse/ZEPPELIN-3552 and https://issues.apache.org/jira/browse/ZEPPELIN-3552
-    # Ignore -Pscala-${SCALA_VERSION} which is now no longer a valid flag
     # Ignore interpreters based on the official Travis configuration
     INTERPRETERS="$(cat .travis.yml | grep INTERPRETERS= | sed -E "s/- INTERPRETERS='(.+)'/\1/" | tr -d " ")"; \
     FLAGS="-DskipTests -Pbuild-distr"; \
     MODULES="-pl ${INTERPRETERS}"; \
-    PROFILES="-Pspark-${SPARK_XY_VERSION} -Pspark-scala-${SCALA_VERSION} -Phadoop2"; \
+    # -Pscala-x.y is only used for v0.8.z, while -Pspark-scala-x.y is used for v0.9.z and onwards
+    if [ "${ZEPPELIN_X_VERSION}" -eq 0 ] && [ "${ZEPPELIN_Y_VERSION}" -le 8 ]; then \
+        SCALA_PROFILE_PREFIX="scala"; \
+    else \
+        SCALA_PROFILE_PREFIX="spark-scala"; \
+    fi; \
+    PROFILES="-Pspark-${SPARK_XY_VERSION} -P${SCALA_PROFILE_PREFIX}-${SCALA_VERSION} -Phadoop2"; \
     mvn clean package ${FLAGS} ${MODULES} ${PROFILES}; \
     cd -; \
     :
@@ -56,11 +66,6 @@ FROM guangie88/spark-custom-addons:${SPARK_VERSION}_scala-${SCALA_VERSION}_hadoo
 
 ARG ZEPPELIN_REV="master"
 ENV ZEPPELIN_HOME "/zeppelin"
-
-# The name of zeppelin directory might not be the same as the ZEPPELIN_REV, especially when building "master" where the directory might be "zeppelin-0.9.0-SNAPSHOT"
-# Below can get the actual Zeppelin version, but can only be done within Docker RUN commands
-# ZEPPELIN_TRIMMED_GIT_URL="$(echo "${ZEPPELIN_GIT_URL}" | sed -E 's/(.+)\.git/\1/gI')"
-# ZEPPELIN_VERSION="$(curl -sL "${ZEPPELIN_TRIMMED_GIT_URL}/raw/${ZEPPELIN_REV}/pom.xml" | grep "<name>Zeppelin</name>" -B1 | grep "<version>" | grep -oE "[[:digit:]]+\.[[:digit:]]+\.[[:digit:]]+(-SNAPSHOT)?")"
 
 # Usage of wildcard works, but be aware that only the files within zeppelin-**/zeppelin-**/ will be copied over
 COPY --from=builder "/tmp/zeppelin/zeppelin-distribution/target/zeppelin-**/zeppelin-**" "${ZEPPELIN_HOME}"

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ ARG PYTHON_VERSION="3.7"
 FROM maven:3-jdk-8-slim as builder
 SHELL ["/bin/bash", "-c"]
 
-ARG ZEPPELIN_REV="master"
+ARG ZEPPELIN_REV="v0.8.2"
 ARG ZEPPELIN_GIT_URL="https://github.com/apache/zeppelin.git"
 
 RUN set -euo pipefail && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -37,7 +37,8 @@ RUN set -euo pipefail && \
     cd -; \
     cd /tmp/zeppelin; \
     SPARK_XY_VERSION="$(echo "${SPARK_VERSION}" | cut -d '.' -f1,2 | tr -d '\n')"; \
-    HADOOP_X_VERSION="$(echo "${HADOOP_VERSION}" | cut -d '.' -f1 | tr -d '\n')"; \
+    # Cannot use Hadoop 3 due to some nested dependency version mismatch issue
+    # HADOOP_X_VERSION="$(echo "${HADOOP_VERSION}" | cut -d '.' -f1 | tr -d '\n')"; \
     # change_scala_version.sh seems deprecated, doesn't even support 2.12 as a param
     # ./dev/change_scala_version.sh "${SCALA_VERSION}"; \
     # See: https://issues.apache.org/jira/browse/ZEPPELIN-3552 and https://issues.apache.org/jira/browse/ZEPPELIN-3552
@@ -45,7 +46,7 @@ RUN set -euo pipefail && \
     INTERPRETERS='!beam,!hbase,!pig,!jdbc,!file,!ignite,!kylin,!lens,!cassandra,!elasticsearch,!bigquery,!alluxio,!scio,!livy,!groovy,!sap,!java,!geode,!neo4j,!hazelcastjet,!submarine,!flink,!angular,!scalding'; \
     FLAGS="-DskipTests -Pbuild-distr"; \
     MODULES="-pl ${INTERPRETERS}"; \
-    PROFILES="-Pspark-${SPARK_XY_VERSION} -Pspark-scala-${SCALA_VERSION} -Phadoop${HADOOP_X_VERSION}"; \
+    PROFILES="-Pspark-${SPARK_XY_VERSION} -Pspark-scala-${SCALA_VERSION} -Phadoop2"; \
     mvn clean package ${FLAGS} ${MODULES} ${PROFILES}; \
     cd -; \
     :

--- a/Dockerfile
+++ b/Dockerfile
@@ -42,7 +42,11 @@ RUN set -euo pipefail && \
     # ./dev/change_scala_version.sh "${SCALA_VERSION}"; \
     # See: https://issues.apache.org/jira/browse/ZEPPELIN-3552 and https://issues.apache.org/jira/browse/ZEPPELIN-3552
     # Ignore -Pscala-${SCALA_VERSION} which is now no longer a valid flag
-    mvn clean package -DskipTests -Pbuild-distr "-Pspark-${SPARK_XY_VERSION}" "-Phadoop${HADOOP_X_VERSION}" "-Pspark-scala-${SCALA_VERSION}"; \
+    INTERPRETERS="!beam,!hbase,!pig,!jdbc,!file,!ignite,!kylin,!lens,!cassandra,!elasticsearch,!bigquery,!alluxio,!scio,!livy,!groovy,!sap,!java,!geode,!neo4j,!hazelcastjet,!submarine,!flink,!angular,!scalding"; \
+    FLAGS="-DskipTests -Pbuild-distr"; \
+    MODULES="-pl ${INTERPRETERS}"; \
+    PROFILES="-Pspark-${SPARK_XY_VERSION} -Pspark-scala-${SCALA_VERSION} -Phadoop${HADOOP_X_VERSION}"; \
+    mvn clean package ${FLAGS} ${MODULES} ${PROFILES}; \
     cd -; \
     :
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -43,7 +43,8 @@ RUN set -euo pipefail && \
     # ./dev/change_scala_version.sh "${SCALA_VERSION}"; \
     # See: https://issues.apache.org/jira/browse/ZEPPELIN-3552 and https://issues.apache.org/jira/browse/ZEPPELIN-3552
     # Ignore -Pscala-${SCALA_VERSION} which is now no longer a valid flag
-    INTERPRETERS='!beam,!hbase,!pig,!jdbc,!file,!ignite,!kylin,!lens,!cassandra,!elasticsearch,!bigquery,!alluxio,!scio,!livy,!groovy,!sap,!java,!geode,!neo4j,!hazelcastjet,!submarine,!flink,!angular,!scalding'; \
+    # Ignore interpreters based on the official Travis configuration
+    INTERPRETERS="$(cat .travis.yml | grep INTERPRETERS= | grep -oE "'.+'")"; \
     FLAGS="-DskipTests -Pbuild-distr"; \
     MODULES="-pl ${INTERPRETERS}"; \
     PROFILES="-Pspark-${SPARK_XY_VERSION} -Pspark-scala-${SCALA_VERSION} -Phadoop2"; \

--- a/Dockerfile
+++ b/Dockerfile
@@ -70,6 +70,13 @@ ENV ZEPPELIN_NOTEBOOK "/zeppelin/notebook"
 # Install JAR loader
 ARG SCALA_VERSION
 
+ARG ZEPPELIN_JAR_LOADER_VERSION="v0.2.1"
+ENV ZEPPELIN_JAR_LOADER_VERSION "${ZEPPELIN_JAR_LOADER_VERSION}"
+
+RUN set -euo pipefail && \
+    wget -P ${SPARK_HOME}/jars/ https://github.com/dsaidgovsg/zeppelin-jar-loader/releases/download/${ZEPPELIN_JAR_LOADER_VERSION}/zeppelin-jar-loader_${SCALA_VERSION}-${ZEPPELIN_JAR_LOADER_VERSION}.jar; \
+    :
+
 # Install custom OAuth authorizer with env domain checker
 # This is required even for general pac4j.oauth
 ARG PAC4J_AUTHORIZER_VERSION="v0.1.1"

--- a/Dockerfile
+++ b/Dockerfile
@@ -42,7 +42,7 @@ RUN set -euo pipefail && \
     # ./dev/change_scala_version.sh "${SCALA_VERSION}"; \
     # See: https://issues.apache.org/jira/browse/ZEPPELIN-3552 and https://issues.apache.org/jira/browse/ZEPPELIN-3552
     # Ignore -Pscala-${SCALA_VERSION} which is now no longer a valid flag
-    INTERPRETERS="!beam,!hbase,!pig,!jdbc,!file,!ignite,!kylin,!lens,!cassandra,!elasticsearch,!bigquery,!alluxio,!scio,!livy,!groovy,!sap,!java,!geode,!neo4j,!hazelcastjet,!submarine,!flink,!angular,!scalding"; \
+    INTERPRETERS='!beam,!hbase,!pig,!jdbc,!file,!ignite,!kylin,!lens,!cassandra,!elasticsearch,!bigquery,!alluxio,!scio,!livy,!groovy,!sap,!java,!geode,!neo4j,!hazelcastjet,!submarine,!flink,!angular,!scalding'; \
     FLAGS="-DskipTests -Pbuild-distr"; \
     MODULES="-pl ${INTERPRETERS}"; \
     PROFILES="-Pspark-${SPARK_XY_VERSION} -Pspark-scala-${SCALA_VERSION} -Phadoop${HADOOP_X_VERSION}"; \


### PR DESCRIPTION
Downgrade back to stable v0.8.2 in order to use JAR loader.

This removes support for 2.12 though, and the status for 2.12 should be ignored for the time being.