### PR TITLE
fix: put back missing JAR loader

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,36 @@
+# Version changes
+
+The changes here are cumulative from oldest to latest version.
+
+In principle, new features can be added to an existing version, but the change
+should not be breaking to existing default `docker run` with default env vars
+set-up.
+
+## v1
+
+This assumes that the default command is used. The default port that Zeppelin
+uses is `8080`. To change it, override the env var `ZEPPELIN_PORT` to any other
+port value.
+
+- Env vars
+  - General
+    - `ZEPPELIN_HOME="/zeppelin"`
+    - `ZEPPELIN_NOTEBOOK="/zeppelin/notebook"`
+    - `ZEPPELIN_IMPERSONATE_USER="zeppelin"`
+    - `ZEPPELIN_IMPERSONATE_CMD="gosu zeppelin bash -c "`
+    - `ZEPPELIN_IMPERSONATE_SPARK_PROXY_USER="false"`
+  - `interpreter.json.template`
+    Too many to list, all Spark interpreter related options do have
+    corresponding env vars to control the value. E.g.:
+    - `SPARK_MASTER`
+    - `SPARK_JARS`
+    - `ZEPPELIN_SPARK_ENABLESUPPORTEDVERSIONCHECK`, etc.
+  - `zeppelin-site.xml.template
+    - `SERVER_ADDR="0.0.0.0"`
+    - `ZEPPELIN_PORT="8080"`
+    - `ZEPPELIN_SSL_PORT="8080"`
+    - `ZEPPELIN_NOTEBOOK` notebook dir location as stated in `General`
+
+- Others
+  - `zeppelin-jar-loader` (only for `0.8.z` and below) and `pac4j-authorizer`
+    JARs are present for use as described in [`README.md`](README.md)

--- a/Dockerfile
+++ b/Dockerfile
@@ -78,21 +78,19 @@ ARG ZEPPELIN_REV
 ARG SCALA_VERSION
 
 ARG ZEPPELIN_JAR_LOADER_VERSION="v0.2.1"
-ENV ZEPPELIN_JAR_LOADER_VERSION "${ZEPPELIN_JAR_LOADER_VERSION}"
-
-# Install custom OAuth authorizer with env domain checker
-# This is required even for general pac4j.oauth
-ARG PAC4J_AUTHORIZER_VERSION="v0.1.1"
-ENV PAC4J_AUTHORIZER_VERSION "${PAC4J_AUTHORIZER_VERSION}"
-
 RUN set -euo pipefail && \
     ZEPPELIN_X_VERSION="$(echo "${ZEPPELIN_REV}" | cut -d '.' -f1)"; \
     ZEPPELIN_Y_VERSION="$(echo "${ZEPPELIN_REV}" | cut -d '.' -f2)"; \
     # Only use the JAR loader for <= 0.8.z, since 0.9.z onwards already dropped support for it
     if [ "${ZEPPELIN_X_VERSION}" -eq 0 ] && [ "${ZEPPELIN_Y_VERSION}" -le 8 ]; then \
-        wget -P ${ZEPPELIN_HOME}/lib/ https://github.com/dsaidgovsg/pac4j-authorizer/releases/download/${PAC4J_AUTHORIZER_VERSION}/pac4j-authorizer_${SCALA_VERSION}-${PAC4J_AUTHORIZER_VERSION}.jar; \
+        wget -P ${SPARK_HOME}/jars/ https://github.com/dsaidgovsg/zeppelin-jar-loader/releases/download/${ZEPPELIN_JAR_LOADER_VERSION}/zeppelin-jar-loader_${SCALA_VERSION}-${ZEPPELIN_JAR_LOADER_VERSION}.jar; \
     fi; \
     :
+
+# Install custom OAuth authorizer with env domain checker
+# This is required even for general pac4j.oauth
+ARG PAC4J_AUTHORIZER_VERSION="v0.1.1"
+RUN wget -P ${ZEPPELIN_HOME}/lib/ https://github.com/dsaidgovsg/pac4j-authorizer/releases/download/${PAC4J_AUTHORIZER_VERSION}/pac4j-authorizer_${SCALA_VERSION}-${PAC4J_AUTHORIZER_VERSION}.jar
 
 RUN set -euo pipefail && \
     # Install gosu for non-root execution

--- a/README.md
+++ b/README.md
@@ -31,6 +31,10 @@ part of the above template files, but note that this is a best effort attempt
 and there is indeed a change of naming (or removal), this would not be reflected
 in the Docker image tags.
 
+## Version changelog
+
+See [`CHANGELOG.md`](CHANGELOG.md) for details.
+
 ## How to have a quick local deployment demo
 
 ```bash


### PR DESCRIPTION
JAR loader was mistaken taken out in previous PR. This puts back the
JAR loader but only for 0.8.z, and adds a CHANGELOG.md.