### PR TITLE
feat(matrix): expand to Zeppelin 0.8.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,9 +11,22 @@ jobs:
     strategy:
       matrix:
         version:
+        # 0.8.1 section
+        - zeppelin: "0.8.1"
+          spark:    "2.4.4"
+          scala:    "2.11"
+          hadoop:   "3.1.0"
+        - zeppelin: "0.8.1"
+          spark:    "2.4.5"
+          scala:    "2.11"
+          hadoop:   "3.1.0"
         # 0.8.2 section
         - zeppelin: "0.8.2"
           spark:    "2.4.4"
+          scala:    "2.11"
+          hadoop:   "3.1.0"
+        - zeppelin: "0.8.2"
+          spark:    "2.4.5"
           scala:    "2.11"
           hadoop:   "3.1.0"
         # 0.9.0-preview1 section

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,5 +32,8 @@ port value.
     - `ZEPPELIN_NOTEBOOK` notebook dir location as stated in `General`
 
 - Others
-  - `zeppelin-jar-loader` (only for `0.8.z` and below) and `pac4j-authorizer`
-    JARs are present for use as described in [`README.md`](README.md)
+  - `zeppelin-jar-loader v0.2.1"` (only for Zeppelin `0.8.1` and below) and
+    `pac4j-authorizer v0.1.1` JARs are present for use as described in
+    [`README.md`](README.md).
+  - `ghafs v0.1.0` executable is present in `PATH`, check
+    <https://github.com/guangie88/ghafs> for more details.

--- a/Dockerfile
+++ b/Dockerfile
@@ -94,8 +94,9 @@ RUN set -euo pipefail && \
     ZEPPELIN_VERSION="${ZEPPELIN_REV:1}"; \
     ZEPPELIN_X_VERSION="$(echo "${ZEPPELIN_VERSION}" | cut -d '.' -f1)"; \
     ZEPPELIN_Y_VERSION="$(echo "${ZEPPELIN_VERSION}" | cut -d '.' -f2)"; \
-    # Only use the JAR loader for <= 0.8.z, since 0.9.z onwards already dropped support for it
-    if [ "${ZEPPELIN_X_VERSION}" -eq 0 ] && [ "${ZEPPELIN_Y_VERSION}" -le 8 ]; then \
+    ZEPPELIN_Z_VERSION="$(echo "${ZEPPELIN_VERSION}" | cut -d '.' -f3)"; \
+    # Only use the JAR loader for <= 0.8.1, since 0.8.2 onwards already dropped support for it
+    if [ "${ZEPPELIN_X_VERSION}" -eq 0 ] && ([ "${ZEPPELIN_Y_VERSION}" -le 8 ] && [ "${ZEPPELIN_Z_VERSION}" -le 1 ] || [ "${ZEPPELIN_Y_VERSION}" -le 7 ]); then \
         wget -P ${SPARK_HOME}/jars/ https://github.com/dsaidgovsg/zeppelin-jar-loader/releases/download/${ZEPPELIN_JAR_LOADER_VERSION}/zeppelin-jar-loader_${SCALA_VERSION}-${ZEPPELIN_JAR_LOADER_VERSION}.jar; \
     fi; \
     :

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ sc.parallelize(0 to 10).sum
 Press `[SHIFT+ENTER]` to run the paragraph. Wait for Spark to compute the above
 and you should get the sum result after some time.
 
-## How to use the dynamic JAR loader (only for v0.8.z and below)
+## How to use the dynamic JAR loader (only for v0.8.1 and below)
 
 By default, Zeppelin supports dynamic JAR loading, but only through Maven
 repository or local filesystem. See
@@ -99,8 +99,8 @@ import com.puppycrawl.tools.checkstyle._
 
 ### Caveat
 
-This only applies to Zeppelin version 0.8.z and below, since 0.9.z drops support
-for it.
+This only applies to Zeppelin version 0.8.1 and below, since 0.8.2 and 0.9.z
+drops support for it.
 
 One mitigation for this is to use a GitHub release asset as filesystem mount, as
 such: <https://github.com/guangie88/ghafs>. This should also work for 0.8.z. The


### PR DESCRIPTION
0.8.2 does not support the JAR loader, so expand to 0.8.1 to at least
ensure a build that works with it.