### PR TITLE
feat(ghafs): update to 0.1.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,5 +35,5 @@ port value.
   - `zeppelin-jar-loader v0.2.1"` (only for Zeppelin `0.8.1` and below) and
     `pac4j-authorizer v0.1.1` JARs are present for use as described in
     [`README.md`](README.md).
-  - `ghafs v0.1.1` executable is present in `PATH`, check
+  - `ghafs v0.1.2` executable is present in `PATH`, check
     <https://github.com/guangie88/ghafs> for more details.

--- a/Dockerfile
+++ b/Dockerfile
@@ -76,7 +76,7 @@ ARG ZEPPELIN_REV
 ARG SCALA_VERSION
 
 # Install GitHub Release Assets FUSE mount CLI (requires fuse install)
-ARG GHAFS_VERSION="v0.1.1"
+ARG GHAFS_VERSION="v0.1.2"
 RUN set -euo pipefail && \
     apk add --no-cache fuse; \
     wget https://github.com/guangie88/ghafs/releases/download/${GHAFS_VERSION}/ghafs-${GHAFS_VERSION}-linux-amd64.tar.gz; \


### PR DESCRIPTION
This patched release performs a refresh when not `ls`-ing the mounted
directory, rather than getting from the cache, which is a more robust
behaviour.