### PR TITLE
feat(envs): change default meaning of not specifying Spark env vars

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -153,7 +153,7 @@ jobs:
       fail-fast: true
     runs-on: ubuntu-latest
     env:
-      SELF_VERSION: "v2.1.0"
+      SELF_VERSION: "v3.0.0"
       IMAGE_NAME: zeppelin
       ZEPPELIN_VERSION: "${{ matrix.version.zeppelin }}"
       ZEPPELIN_REV:     "${{ matrix.version.zeppelin_rev }}"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,28 @@ In principle, new features can be added to an existing version, but the change
 should not be breaking to existing default `docker run` with default env vars
 set-up.
 
+## v3.0.0
+
+- Change default behaviour of not supplying the following Spark env vars (all of
+  them from previous version). No values will be used instead, leaving it to use
+  `spark-defaults.conf` if you have.
+  - `SPARK_MASTER`
+  - `SPARK_JARS`
+  - `SPARK_SUBMIT_DEPLOYMODE`
+  - `SPARK_APP_NAME`
+  - `SPARK_ARGS`
+  - `SPARK_EXECUTOR_MEMORY`
+  - `SPARK_EVENTLOG_ENABLED`
+  - `SPARK_EVENTLOG_DIR`
+  - `SPARK_CORES_MAX`
+  - `SPARK_SHUFFLE_SERVICE_ENABLED`
+  - `SPARK_DYNAMICALLOCATION_ENABLED`
+  - `SPARK_DYNAMICALLOCATION_MAXEXECUTORS`
+  - `SPARK_DYNAMICALLOCATION_CACHEDEXECUTORIDLETIMEOUT`
+- Change the following env var names:
+  - `SPARK_INTERPRETER_PER_NOTE` to `ZEPPELIN_SPARK_INTERPRETER_PER_NOTE`
+  - `SPARK_INTERPRETER_PER_USER` to `ZEPPELIN_SPARK_INTERPRETER_PER_USER`
+
 ## v2.1.0
 
 - Allow application of existing template to be optional:
@@ -18,7 +40,6 @@ set-up.
 
 ## v2.0.0
 
-- Allow
 - Use Kubernetes supported Spark image.
 - Change from Alpine to Debian because of Kubernetes support.
 - Drops `zeppelin-jar-loader`.

--- a/docker/conf/interpreter.json.template
+++ b/docker/conf/interpreter.json.template
@@ -101,70 +101,96 @@
       "name": "spark",
       "group": "spark",
       "properties": {
+{%- if SPARK_MASTER %}
         "master": {
           "name": "master",
-          "value": "{{ SPARK_MASTER | default(value='local[*]') }}",
+          "value": "{{ SPARK_MASTER }}",
           "type": "string"
         },
+{%- endif %}
+{%- if SPARK_JARS %}
         "spark.jars": {
           "name": "spark.jars",
-          "value": "{{ SPARK_JARS | default(value='') }}"
+          "value": "{{ SPARK_JARS }}"
         },
+{%- endif %}
+{%- if SPARK_SUBMIT_DEPLOYMODE %}
         "spark.submit.deployMode": {
           "name": "spark.submit.deployMode",
-          "value": "{{ SPARK_SUBMIT_DEPLOYMODE | default(value='client') }}",
+          "value": "{{ SPARK_SUBMIT_DEPLOYMODE }}",
           "type": "string"
         },
+{%- endif %}
+{%- if SPARK_APP_NAME %}
         "spark.app.name": {
           "name": "spark.app.name",
-          "value": "{{ SPARK_APP_NAME | default(value='Zeppelin') }}",
+          "value": "{{ SPARK_APP_NAME }}",
           "type": "string"
         },
+{%- endif %}
+{%- if SPARK_ARGS %}
         "args": {
           "name": "args",
-          "value": "{{ SPARK_ARGS | default(value='') }}",
+          "value": "{{ SPARK_ARGS }}",
           "type": "textarea"
         },
+{%- endif %}
+{%- if SPARK_EXECUTOR_MEMORY %}
         "spark.executor.memory": {
           "name": "spark.executor.memory",
-          "value": "{{ SPARK_EXECUTOR_MEMORY | default(value='4G') }}",
+          "value": "{{ SPARK_EXECUTOR_MEMORY }}",
           "type": "string"
         },
+{%- endif %}
+{%- if SPARK_EVENTLOG_ENABLED %}
         "spark.eventLog.enabled": {
           "name": "spark.eventLog.enabled",
-          "value": "{{ SPARK_EVENTLOG_ENABLED | default(value='false') }}",
+          "value": "{{ SPARK_EVENTLOG_ENABLED }}",
           "type": "string"
         },
+{%- endif %}
+{%- if SPARK_EVENTLOG_DIR %}
         "spark.eventLog.dir": {
           "name": "spark.eventLog.dir",
-          "value": "{{ SPARK_EVENTLOG_DIR | default(value='') }}",
+          "value": "{{ SPARK_EVENTLOG_DIR }}",
           "type": "string"
         },
+{%- endif %}
+{%- if SPARK_CORES_MAX %}
         "spark.cores.max": {
           "name": "spark.cores.max",
-          "value": "{{ SPARK_CORES_MAX | default(value='') }}",
+          "value": "{{ SPARK_CORES_MAX }}",
           "type": "number"
         },
+{%- endif %}
+{%- if SPARK_SHUFFLE_SERVICE_ENABLED %}
         "spark.shuffle.service.enabled": {
           "name": "spark.shuffle.service.enabled",
-          "value": "{{ SPARK_SHUFFLE_SERVICE_ENABLED | default(value='true') }}",
+          "value": "{{ SPARK_SHUFFLE_SERVICE_ENABLED }}",
           "type": "string"
         },
+{%- endif %}
+{%- if SPARK_DYNAMICALLOCATION_ENABLED %}
         "spark.dynamicAllocation.enabled": {
           "name": "spark.dynamicAllocation.enabled",
-          "value": "{{ SPARK_DYNAMICALLOCATION_ENABLED | default(value='true') }}",
+          "value": "{{ SPARK_DYNAMICALLOCATION_ENABLED }}",
           "type": "string"
         },
+{%- endif %}
+{%- if SPARK_DYNAMICALLOCATION_MAXEXECUTORS %}
         "spark.dynamicAllocation.maxExecutors": {
           "name": "spark.dynamicAllocation.maxExecutors",
-          "value": "{{ SPARK_DYNAMICALLOCATION_MAXEXECUTORS | default(value='25') }}",
+          "value": "{{ SPARK_DYNAMICALLOCATION_MAXEXECUTORS }}",
           "type": "string"
         },
+{%- endif %}
+{%- if SPARK_DYNAMICALLOCATION_CACHEDEXECUTORIDLETIMEOUT %}
         "spark.dynamicAllocation.cachedExecutorIdleTimeout": {
           "name": "spark.dynamicAllocation.cachedExecutorIdleTimeout",
-          "value": "{{ SPARK_DYNAMICALLOCATION_CACHEDEXECUTORIDLETIMEOUT | default(value='60s') }}",
+          "value": "{{ SPARK_DYNAMICALLOCATION_CACHEDEXECUTORIDLETIMEOUT }}",
           "type": "string"
         },
+{%- endif %}
         "zeppelin.spark.sql.interpolation": {
           "name": "zeppelin.spark.sql.interpolation",
           "value": {{ ZEPPELIN_SPARK_SQL_INTERPOLATION | default(value='false') }},
@@ -307,8 +333,8 @@
       "option": {
         "remote": true,
         "port": -1,
-        "perNote": "{{ SPARK_INTERPRETER_PER_NOTE | default(value='isolated') }}",
-        "perUser": "{{ SPARK_INTERPRETER_PER_USER | default(value='isolated') }}",
+        "perNote": "{{ ZEPPELIN_SPARK_INTERPRETER_PER_NOTE | default(value='isolated') }}",
+        "perUser": "{{ ZEPPELIN_SPARK_INTERPRETER_PER_USER | default(value='isolated') }}",
         "isExistingProcess": false,
         "setPermission": false,
         "owners": [],

--- a/templates/vars.yml
+++ b/templates/vars.yml
@@ -1,4 +1,4 @@
-self_version: "v2.1.0"
+self_version: "v3.0.0"
 
 versions:
 - zeppelin: ["0.8.2"]


### PR DESCRIPTION
There will not be default interpolated values now to facilitate the use
of `spark-defaults.conf` for users' convenience.

All empty values will use values from `spark-defaults.conf` by default.

BREAKING CHANGE: different values for Spark when env vars are not
specified.