### PR TITLE
fix: replace log4j with reload4j

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,6 +30,13 @@ RUN set -euo pipefail && \
     rm zeppelin-${ZEPPELIN_VERSION}-bin-netinst.tgz; \
     :
 
+# Download reload4j jar
+ARG RELOAD4J_VERSION="1.2.25"
+RUN set -euo pipefail && \
+    wget "https://repo1.maven.org/maven2/ch/qos/reload4j/reload4j/${RELOAD4J_VERSION}/reload4j-${RELOAD4J_VERSION}.jar" -O ${ZEPPELIN_HOME}/lib/reload4j-${RELOAD4J_VERSION}.jar;\ 
+    rm ${ZEPPELIN_HOME}/lib/log4j-1.2.17.jar; \
+    :
+
 RUN set -euo pipefail && \
     # Install tera-cli for runtime interpolation
     wget https://github.com/guangie88/tera-cli/releases/download/v0.4.1/tera-cli-v0.4.1-x86_64-unknown-linux-musl.tar.gz; \

--- a/Dockerfile
+++ b/Dockerfile
@@ -33,9 +33,10 @@ RUN set -euo pipefail && \
 # Download reload4j jar
 ARG RELOAD4J_VERSION="1.2.25"
 RUN set -euo pipefail && \
-    wget "https://repo1.maven.org/maven2/csh/qos/reload4j/reload4j/${RELOAD4J_VERSION}/reload4j-${RELOAD4J_VERSION}.jar" -O ${ZEPPELIN_HOME}/lib/reload4j-${RELOAD4J_VERSION}.jar;\ 
-    rm ${ZEPPELIN_HOME}/lib/log4j-1.2.17.jar; \
-   
+    wget "https://repo1.maven.org/maven2/ch/qos/reload4j/reload4j/${RELOAD4J_VERSION}/reload4j-${RELOAD4J_VERSION}.jar" -O /zeppelin/lib/reload4j-${RELOAD4J_VERSION}.jar; \
+    rm /zeppelin/lib/log4j-1.2.17.jar; \
+    :
+
 # Install GitHub Release Assets FUSE mount CLI (requires fuse install)
 ARG GHAFS_VERSION="v0.1.3"
 RUN set -euo pipefail && \

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ docker build . -t zeppelin \
     --build-arg SCALA_VERSION="${SCALA_VERSION}" \
     --build-arg JAVA_VERSION="${JAVA_VERSION}"
 
-docker run --rm -it --name zeppelin -p 8080:8080 zeppelin
+docker run -d --rm -it --name zeppelin -p 8080:8080 zeppelin
 ```
 
 Wait a while and then access <http://localhost:8080/> in your web browser.


### PR DESCRIPTION
# Context
log4j-1.2.17 is pinned to be a dependency for the latest version of zeppelin, hence reload4j is used to replace log4j-1.2.17 without source code changes.